### PR TITLE
Rename project and update README with setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,147 @@
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
 </p>
 
-## About Laravel
+# Laravel Medium Clone
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+A Medium-like blogging platform built with Laravel 12, featuring article publishing, user authentication, and media
+management.
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Requirements
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+- PHP 8.2 or higher
+- Composer
+- Node.js 18+ and npm
+- SQLite (default) or MySQL/PostgreSQL
+
+## Setup Instructions
+
+### Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/yourusername/laravel-medium-clone.git
+   cd laravel-medium-clone
+   ```
+
+2. Install PHP dependencies:
+   ```bash
+   composer install
+   ```
+
+3. Install JavaScript dependencies:
+   ```bash
+   npm install
+   ```
+
+4. Copy the environment file:
+   ```bash
+   cp .env.example .env
+   ```
+
+5. Generate application key:
+   ```bash
+   php artisan key:generate
+   ```
+
+### Database Setup
+
+The project is configured to use SQLite by default:
+
+1. First, ensure your file has the correct database configuration: `.env`
+
+```bash
+DB_CONNECTION=sqlite
+DB_DATABASE=/absolute/path/to/your/project/database/database.sqlite
+```
+
+**Note:** You can remove other DB_* variables (DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD) as they're not needed for
+SQLite.
+
+2. Create the SQLite database file:
+   ```bash
+   touch database/database.sqlite
+   ```
+
+3. Run migrations:
+   ```bash
+   php artisan migrate
+   ```
+
+4. (Optional) Seed the database with sample data:
+   ```bash
+   php artisan db:seed
+   ```
+
+If you want to start fresh at any point, you can use:
+
+```bash
+ php artisan migrate:fresh
+```
+
+This will drop all tables and re-run all migrations. Add `--seed` flag if you want to reseed the database:
+
+```bash
+php artisan migrate:fresh --seed
+```
+
+### Running the Application
+
+You can run the application using the custom dev script that starts the Laravel server, queue worker, and Vite
+development server concurrently:
+
+```bash
+ composer dev
+```
+
+Or run each service separately:
+
+1. Start the Laravel development server:
+   ```bash
+   php artisan serve
+   ```
+
+2. Start the queue worker:
+   ```bash
+   php artisan queue:listen
+   ```
+
+3. Compile assets with Vite:
+   ```bash
+   npm run dev
+   ```
+
+The application will be available at http://localhost:8000
+
+### Testing
+
+This project uses PestPHP for testing. To run the tests:
+
+```bash
+php artisan test
+```
+
+Or to run tests with Pest directly:
+
+```bash
+./vendor/bin/pest
+```
 
 ## Learning Laravel
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all
+modern web application frameworks, making it a breeze to get started with the framework.
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a
+modern Laravel application from scratch.
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video
+tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging
+into our comprehensive video library.
 
 ## Laravel Sponsors
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in
+becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
 
 ### Premium Partners
 
@@ -51,15 +167,18 @@ We would like to extend our thanks to the following sponsors for funding Laravel
 
 ## Contributing
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+Thank you for considering contributing to the Laravel framework! The contribution guide can be found in
+the [Laravel documentation](https://laravel.com/docs/contributions).
 
 ## Code of Conduct
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+In order to ensure that the Laravel community is welcoming to all, please review and abide by
+the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
 
 ## Security Vulnerabilities
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell
+via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-course",
+    "name": "laravel-medium-clone",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
The project name was changed from "laravel-course" to "laravel-medium-clone" in the package-lock file. The README was updated extensively to include installation, setup, and usage instructions for the Laravel Medium Clone application.